### PR TITLE
Clean up sources.list.d directory to avoid further issues with apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -qqy nginx-amplify-agent \
     && apt-get purge -qqy curl apt-transport-https apt-utils gnupg1 \
+    && rm -rf /etc/apt/sources.list.d/nginx-amplify.list \
     && rm -rf /var/lib/apt/lists/*
 
 # Keep the nginx logs inside the container


### PR DESCRIPTION
/cc @thresheek 

follow up: https://github.com/nginxinc/docker-nginx-amplify/pull/10

Clean up steps include removal of apt-transport-https package hence apt-get going to fail because of https source list nginx-amplify.list left configured, let's make clean up steps complete.
